### PR TITLE
Bugfix: Use correct transform matrix in surface_fit_pc_align.py

### DIFF
--- a/SurfaceFit/surface_fit_pc_align.py
+++ b/SurfaceFit/surface_fit_pc_align.py
@@ -340,7 +340,7 @@ def main(ref_dtm,ref_format,socet_dtm,socet_format,socet_gpf,tfm_socet_gpf,
     ## Build arguments list and apply transformation to selected points from GPF using pc_align
     
     ## Set num-iterations = 0 and turn off max-displacement (-1) because only going to apply existing transform
-    transform_matrix = (align_prefix + '-transform.txt')
+    transform_matrix = (align_prefix + '-inverse-transform.txt')
     apply_tfm_args = ["--initial-transform",transform_matrix,
                       "--num-iterations","0",
                       "--max-displacement","-1",


### PR DESCRIPTION
Second call to pc_align now correctly uses _inverse_ transform from first call.